### PR TITLE
Add Arch/EndeavourOS support

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,3 +2,4 @@
 collections:
   - name: 'community.general'
     version: ">=7.5.0,<=8.0.0"
+  - name: 'kewlfft.aur'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,9 @@
 - name: Install wlsunset
   ansible.builtin.import_tasks:
     file: "wlsunset.yml"
-  when: sway__wlsunset | bool
+  when: 
+    - sway__wlsunset | bool
+    - ansible_os_family != 'Archlinux'
 
 - name: Create sway configuration and features
   ansible.builtin.import_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,11 @@
     file: "setup-Debian.yml"
   when: ansible_os_family == 'Debian'
 
+- name: Ensure sway packages are installed [Archlinux]
+  ansible.builtin.include_tasks:
+    file: "setup-Archlinux.yml"
+  when: ansible_os_family == 'Archlinux'
+
 - name: Install wlsunset
   ansible.builtin.import_tasks:
     file: "wlsunset.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Install wlsunset
   ansible.builtin.import_tasks:
     file: "wlsunset.yml"
-  when: 
+  when:
     - sway__wlsunset | bool
     - ansible_os_family != 'Archlinux'
 

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -1,4 +1,8 @@
 ---
+- name: Include OS-specific variables (Archlinux)
+  ansible.builtin.include_vars:
+    file: "Archlinux.yml"
+
 - name: Create the `aur_builder` user
   become: true
   ansible.builtin.user:
@@ -22,20 +26,5 @@
     use: auto
   become: true
   become_user: aur_builder
-  loop: "{{ sway_packages }}"
-  vars:
-    sway_packages:
-      - 'sway'
-      - 'swaylock'
-      - 'swaybg'
-      - 'swayidle'
-      - 'wdisplays'
-      - 'waybar'
-      - 'cmatrix'
-      - "{{ sway__term_pkgs }}"
-      - "{{ sway__install_launcher }}"
-      - "{{ 'ttf-font-awesome' if sway__dynamic_names | bool else '' }}"
-      - "{{ 'swaync' if sway__notification_center | bool else '' }}"
-  loop_control:
-    label: "{{ item if item is string else item | to_json }}"
+  loop: "{{ sway_arch_packages + sway_arch_packages_extra }}"
   when: item | length > 0

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -3,21 +3,23 @@
   ansible.builtin.include_vars:
     file: "Archlinux.yml"
 
-- name: Create the `aur_builder` user
+- name: Create the AUR builder user
   become: true
   ansible.builtin.user:
-    name: aur_builder
+    name: "{{ sway__aur_builder_username }}"
     create_home: true
     group: wheel
+  when: sway__create_aur_builder | bool
 
-- name: Allow the `aur_builder` user to run `sudo pacman` without a password
+- name: Allow the AUR builder user to run `sudo pacman` without a password
   become: true
   ansible.builtin.lineinfile:
-    path: /etc/sudoers.d/11-install-aur_builder
-    line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'
+    path: "/etc/sudoers.d/11-install-{{ sway__aur_builder_username }}"
+    line: '{{ sway__aur_builder_username }} ALL=(ALL) NOPASSWD: /usr/bin/pacman'
     create: true
     mode: 0644
     validate: 'visudo -cf %s'
+  when: sway__create_aur_builder | bool
 
 - name: Ensure required sway packages are installed from AUR
   kewlfft.aur.aur:
@@ -25,6 +27,8 @@
     state: present
     use: auto
   become: true
-  become_user: aur_builder
+  become_user: "{{ sway__aur_builder_username }}"
   loop: "{{ sway_arch_packages + sway_arch_packages_extra }}"
-  when: item | length > 0
+  when: 
+    - item | length > 0
+    - sway__create_aur_builder | bool

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -15,54 +15,27 @@
     mode: 0644
     validate: 'visudo -cf %s'
 
-- name: Ensure swaywm is installed from AUR
+- name: Ensure required sway packages are installed from AUR
   kewlfft.aur.aur:
     name: "{{ item }}"
     state: present
     use: auto
   become: true
   become_user: aur_builder
-  with_items:
-    - 'sway'
-    - 'swaylock'
-    - 'swaybg'
-    - 'swayidle'
-    - 'wdisplays'
-    - 'waybar'
-    - 'cmatrix'
-
-- name: Ensure font-awesome is installed from AUR
-  kewlfft.aur.aur:
-    name: "ttf-font-awesome"
-    state: present
-    use: auto
-  become: true
-  become_user: aur_builder
-  when: sway__dynamic_names | bool
-
-- name: Ensure terminal Packages are installed from AUR
-  kewlfft.aur.aur:
-    name: "{{ item }}"
-    state: present
-    use: auto
-  become: true
-  become_user: aur_builder
-  with_items: "{{ sway__term_pkgs }}"
-
-- name: Ensure launcher Packages are installed from AUR
-  kewlfft.aur.aur:
-    name: "{{ item }}"
-    state: present
-    use: auto
-  become: true
-  become_user: aur_builder
-  with_items: "{{ sway__install_launcher }}"
-
-- name: Ensure sway notification center is installed from AUR
-  kewlfft.aur.aur:
-    name: "swaync"
-    state: present
-    use: auto
-  become: true
-  become_user: aur_builder
-  when: sway__notification_center | bool
+  loop: "{{ sway_packages }}"
+  vars:
+    sway_packages:
+      - 'sway'
+      - 'swaylock'
+      - 'swaybg'
+      - 'swayidle'
+      - 'wdisplays'
+      - 'waybar'
+      - 'cmatrix'
+      - "{{ sway__term_pkgs }}"
+      - "{{ sway__install_launcher }}"
+      - "{{ 'ttf-font-awesome' if sway__dynamic_names | bool else '' }}"
+      - "{{ 'swaync' if sway__notification_center | bool else '' }}"
+  loop_control:
+    label: "{{ item if item is string else item | to_json }}"
+  when: item | length > 0

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -3,7 +3,7 @@
   become: true
   ansible.builtin.user:
     name: aur_builder
-    create_home: yes
+    create_home: true
     group: wheel
 
 - name: Allow the `aur_builder` user to run `sudo pacman` without a password
@@ -11,7 +11,7 @@
   ansible.builtin.lineinfile:
     path: /etc/sudoers.d/11-install-aur_builder
     line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'
-    create: yes
+    create: true
     mode: 0644
     validate: 'visudo -cf %s'
 

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -1,7 +1,68 @@
 ---
-- name: Ensure i3 packages are installed  # noqa: H1901
-  community.general.pacman:
-    name: "{{ i3_packages }}"
-    state: present
-    update_cache: true
+- name: Create the `aur_builder` user
   become: true
+  ansible.builtin.user:
+    name: aur_builder
+    create_home: yes
+    group: wheel
+
+- name: Allow the `aur_builder` user to run `sudo pacman` without a password
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/sudoers.d/11-install-aur_builder
+    line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'
+    create: yes
+    mode: 0644
+    validate: 'visudo -cf %s'
+
+- name: Ensure swaywm is installed from AUR
+  kewlfft.aur.aur:
+    name: "{{ item }}"
+    state: present
+    use: auto
+  become: true
+  become_user: aur_builder
+  with_items:
+    - 'sway'
+    - 'swaylock'
+    - 'swaybg'
+    - 'swayidle'
+    - 'wdisplays'
+    - 'waybar'
+    - 'cmatrix'
+
+- name: Ensure font-awesome is installed from AUR
+  kewlfft.aur.aur:
+    name: "ttf-font-awesome"
+    state: present
+    use: auto
+  become: true
+  become_user: aur_builder
+  when: sway__dynamic_names | bool
+
+- name: Ensure terminal Packages are installed from AUR
+  kewlfft.aur.aur:
+    name: "{{ item }}"
+    state: present
+    use: auto
+  become: true
+  become_user: aur_builder
+  with_items: "{{ sway__term_pkgs }}"
+
+- name: Ensure launcher Packages are installed from AUR
+  kewlfft.aur.aur:
+    name: "{{ item }}"
+    state: present
+    use: auto
+  become: true
+  become_user: aur_builder
+  with_items: "{{ sway__install_launcher }}"
+
+- name: Ensure sway notification center is installed from AUR
+  kewlfft.aur.aur:
+    name: "swaync"
+    state: present
+    use: auto
+  become: true
+  become_user: aur_builder
+  when: sway__notification_center | bool

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -29,6 +29,6 @@
   become: true
   become_user: "{{ sway__aur_builder_username }}"
   loop: "{{ sway_arch_packages + sway_arch_packages_extra }}"
-  when: 
+  when:
     - item | length > 0
     - sway__create_aur_builder | bool

--- a/tasks/waybar.yml
+++ b/tasks/waybar.yml
@@ -10,6 +10,7 @@
     - 'qpwgraph'
     - 'pavucontrol'
     - 'light'
+  when: ansible_os_family != 'Archlinux'
 
 - name: Create waybar config folder
   become: true

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,22 +1,4 @@
 ---
-__i3_packages:
-  - i3
-  - i3-gaps
-  # - i3-wm
-  - i3blocks
-  - i3lock
-  - i3status
-  - rofi
-  - feh
-  - tmux
-  - terminator
-  - i3lock
-  - xautolock
-  - maim
-  - imagemagick
-  - fonts-fork-awesome
-  - pulsemixer
-
 # Default Arch Linux package list
 sway_arch_packages:
   - 'sway'

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -12,6 +12,7 @@ sway_arch_packages:
   - "{{ sway__install_launcher }}"
   - "{{ 'ttf-font-awesome' if sway__dynamic_names | bool else '' }}"
   - "{{ 'swaync' if sway__notification_center | bool else '' }}"
+  - "{{ 'wlsunset' if sway__wlsunset | bool else '' }}"
 
 # Extra packages that users can define
 sway_arch_packages_extra: []

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -16,3 +16,21 @@ __i3_packages:
   - imagemagick
   - fonts-fork-awesome
   - pulsemixer
+
+# Default Arch Linux package list
+sway_arch_packages:
+  - 'sway'
+  - 'swaylock'
+  - 'swaybg'
+  - 'swayidle'
+  - 'wdisplays'
+  - 'waybar'
+  - 'cmatrix'
+  - "{{ sway__term_pkgs }}"
+  - "{{ sway__install_launcher }}"
+  - "{{ 'ttf-font-awesome' if sway__dynamic_names | bool else '' }}"
+  - "{{ 'swaync' if sway__notification_center | bool else '' }}"
+
+# Extra packages that users can define
+sway_arch_packages_extra: []
+

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -24,4 +24,3 @@ sway_arch_packages_extra: []
 # AUR builder configuration
 sway__aur_builder_username: "aur_builder"
 sway__create_aur_builder: true
-

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -16,3 +16,7 @@ sway_arch_packages:
 # Extra packages that users can define
 sway_arch_packages_extra: []
 
+# AUR builder configuration
+sway__aur_builder_username: "aur_builder"
+sway__create_aur_builder: true
+

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -8,6 +8,10 @@ sway_arch_packages:
   - 'wdisplays'
   - 'waybar'
   - 'cmatrix'
+  - 'qpwgraph'
+  - 'pavucontrol'
+  - 'wlogout'
+  - 'light'
   - "{{ sway__term_pkgs }}"
   - "{{ sway__install_launcher }}"
   - "{{ 'ttf-font-awesome' if sway__dynamic_names | bool else '' }}"


### PR DESCRIPTION
Enable this role on Arch-based systems by detecting Arch/EndeavourOS, creating an aur_builder user for AUR installs, and installing Sway + related packages - without impacting Debian workflows.